### PR TITLE
Update ESerialDriver.cpp

### DIFF
--- a/ESerialDriver.cpp
+++ b/ESerialDriver.cpp
@@ -95,21 +95,16 @@ void ESerialDriver::show(){
 	
 	if (_type == SERIAL_RENARD)
 		_serial->write(_ptr, _size+2);
+//Changed Serial_DMX to function correctly when using RenardESP stick to replace RS-485 Chip on DMX Compatible controllers
+//Verified working 6/3/2016 on Lynx Express V5, Will test LOR CTB16PC(will kill output likely), and LOR CMB24D next
   else if(_type == SERIAL_DMX){
-		// send the break by sending a slow 0 byte
-		_serial->begin(125000);
+		_serial->begin(83333, SERIAL_8N1);
 		_serial->write(0);
 		_serial->flush();
-		_serial->begin(250000);
+		_serial->begin(250000, SERIAL_8N2);
 		_serial->write(0);
 		_serial->write(_ptr, _size);
+		_serial->flush();
 	}
-		
-	
-	//_serial->flush();  //this may be needed later
-	
 	free(_ptr);
-	
-	
-	
 }


### PR DESCRIPTION
Built RenardESP stick to possibly expand use as an ESP8266 RS485 chip replacement in holiday lighting controllers, I knew the DMX Serial side was untested and this hasn't been tested on non renard hardware, Banged my head into the wall a few dozen times when DMX Control didn't work and realized we do need to add a 83333 vs the 125000 baud break, with serial 8N1, then follow it by going to 250000 at Serial 8N2, verified working on Lynx Express V5.1 and V5.0 while retaining DMX OUT 2.  Will test in the next day or two on a LOR CTB16PC, and CMB24D, although I predict this will break the output on the LOR controllers.